### PR TITLE
feat: change gcs region from US to ASIA

### DIFF
--- a/1-org/envs/shared/variables.tf
+++ b/1-org/envs/shared/variables.tf
@@ -105,7 +105,7 @@ variable "data_access_logs_enabled" {
 variable "log_export_storage_location" {
   description = "The location of the storage bucket used to export logs."
   type        = string
-  default     = "US"
+  default     = "ASIA"
 }
 
 variable "log_export_storage_force_destroy" {


### PR DESCRIPTION
By default, GCS region for logging is set to `US`. Changing it to `ASIA` instead in case of any compliance reasons (e.g. data residency).