### PR TITLE
feat: toggle for enabling envs in 2-environments

### DIFF
--- a/2-environments/envs/development/README.md
+++ b/2-environments/envs/development/README.md
@@ -10,6 +10,7 @@
 | parent\_folder | Optional - for an organization with existing projects or for development/validation. It will place all the example foundation resources under the provided folder instead of the root organization. The value is the numeric folder ID. The folder must already exist. Must be the same value used in previous step. | `string` | `""` | no |
 | project\_prefix | Name prefix to use for projects created. Should be the same in all steps. Max size is 3 characters. | `string` | `"prj"` | no |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | `string` | n/a | yes |
+| enable\_development | To enable creation of the development environment. | `bool` | n/a | yes |
 
 ## Outputs
 

--- a/2-environments/envs/development/main.tf
+++ b/2-environments/envs/development/main.tf
@@ -17,6 +17,8 @@
 module "env" {
   source = "../../modules/env_baseline"
 
+  count  = var.enable_development ? 1 : 0
+
   env              = "development"
   environment_code = "d"
 

--- a/2-environments/envs/development/outputs.tf
+++ b/2-environments/envs/development/outputs.tf
@@ -16,25 +16,25 @@
 
 output "env_folder" {
   description = "Environment folder created under parent."
-  value       = module.env.env_folder
+  value       = join("", module.env.env_folder)
 }
 
 output "monitoring_project_id" {
   description = "Project for monitoring infra."
-  value       = module.env.monitoring_project_id
+  value       = join("", module.env.monitoring_project_id)
 }
 
 output "base_shared_vpc_project_id" {
   description = "Project for base shared VPC."
-  value       = module.env.base_shared_vpc_project_id
+  value       = join("", module.env.base_shared_vpc_project_id)
 }
 
 output "restricted_shared_vpc_project_id" {
   description = "Project for restricted shared VPC."
-  value       = module.env.restricted_shared_vpc_project_id
+  value       = join("", module.env.restricted_shared_vpc_project_id)
 }
 
 output "env_secrets_project_id" {
   description = "Project for environment related secrets."
-  value       = module.env.env_secrets_project_id
+  value       = join("", module.env.env_secrets_project_id)
 }

--- a/2-environments/envs/development/variables.tf
+++ b/2-environments/envs/development/variables.tf
@@ -51,3 +51,19 @@ variable "folder_prefix" {
   type        = string
   default     = "fldr"
 }
+
+
+variable "enable_development" {
+  description = "To enable creation of the development environment."
+  type        = bool
+}
+
+variable "enable_non_production" {
+  description = "To enable creation of the non-production environment."
+  type        = bool
+}
+
+variable "enable_production" {
+  description = "To enable creation of the production environment."
+  type        = bool
+}

--- a/2-environments/envs/non-production/README.md
+++ b/2-environments/envs/non-production/README.md
@@ -10,6 +10,7 @@
 | parent\_folder | Optional - for an organization with existing projects or for development/validation. It will place all the example foundation resources under the provided folder instead of the root organization. The value is the numeric folder ID. The folder must already exist. Must be the same value used in previous step. | `string` | `""` | no |
 | project\_prefix | Name prefix to use for projects created. Should be the same in all steps. Max size is 3 characters. | `string` | `"prj"` | no |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | `string` | n/a | yes |
+| enable\_non\_production | To enable creation of the non-production environment. | `bool` | n/a | yes |
 
 ## Outputs
 

--- a/2-environments/envs/non-production/main.tf
+++ b/2-environments/envs/non-production/main.tf
@@ -17,6 +17,8 @@
 module "env" {
   source = "../../modules/env_baseline"
 
+  count  = var.enable_non_production ? 1 : 0
+
   env              = "non-production"
   environment_code = "n"
 

--- a/2-environments/envs/non-production/outputs.tf
+++ b/2-environments/envs/non-production/outputs.tf
@@ -16,25 +16,25 @@
 
 output "env_folder" {
   description = "Environment folder created under parent."
-  value       = module.env.env_folder
+  value       = join("", module.env.env_folder)
 }
 
 output "monitoring_project_id" {
   description = "Project for monitoring infra."
-  value       = module.env.monitoring_project_id
+  value       = join("", module.env.monitoring_project_id)
 }
 
 output "base_shared_vpc_project_id" {
   description = "Project for base shared VPC."
-  value       = module.env.base_shared_vpc_project_id
+  value       = join("", module.env.base_shared_vpc_project_id)
 }
 
 output "restricted_shared_vpc_project_id" {
   description = "Project for restricted shared VPC."
-  value       = module.env.restricted_shared_vpc_project_id
+  value       = join("", module.env.restricted_shared_vpc_project_id)
 }
 
 output "env_secrets_project_id" {
   description = "Project for environment related secrets."
-  value       = module.env.env_secrets_project_id
+  value       = join("", module.env.env_secrets_project_id)
 }

--- a/2-environments/envs/non-production/variables.tf
+++ b/2-environments/envs/non-production/variables.tf
@@ -51,3 +51,19 @@ variable "folder_prefix" {
   type        = string
   default     = "fldr"
 }
+
+
+variable "enable_development" {
+  description = "To enable creation of the development environment."
+  type        = bool
+}
+
+variable "enable_non_production" {
+  description = "To enable creation of the non-production environment."
+  type        = bool
+}
+
+variable "enable_production" {
+  description = "To enable creation of the production environment."
+  type        = bool
+}

--- a/2-environments/envs/production/README.md
+++ b/2-environments/envs/production/README.md
@@ -10,6 +10,7 @@
 | parent\_folder | Optional - for an organization with existing projects or for development/validation. It will place all the example foundation resources under the provided folder instead of the root organization. The value is the numeric folder ID. The folder must already exist. Must be the same value used in previous step. | `string` | `""` | no |
 | project\_prefix | Name prefix to use for projects created. Should be the same in all steps. Max size is 3 characters. | `string` | `"prj"` | no |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | `string` | n/a | yes |
+| enable\_production | To enable creation of the production environment. | `bool` | n/a | yes |
 
 ## Outputs
 

--- a/2-environments/envs/production/main.tf
+++ b/2-environments/envs/production/main.tf
@@ -17,6 +17,8 @@
 module "env" {
   source = "../../modules/env_baseline"
 
+  count  = var.enable_production ? 1 : 0
+
   env              = "production"
   environment_code = "p"
 

--- a/2-environments/envs/production/outputs.tf
+++ b/2-environments/envs/production/outputs.tf
@@ -16,25 +16,25 @@
 
 output "env_folder" {
   description = "Environment folder created under parent."
-  value       = module.env.env_folder
+  value       = join("", module.env.env_folder)
 }
 
 output "monitoring_project_id" {
   description = "Project for monitoring infra."
-  value       = module.env.monitoring_project_id
+  value       = join("", module.env.monitoring_project_id)
 }
 
 output "base_shared_vpc_project_id" {
   description = "Project for base shared VPC."
-  value       = module.env.base_shared_vpc_project_id
+  value       = join("", module.env.base_shared_vpc_project_id)
 }
 
 output "restricted_shared_vpc_project_id" {
   description = "Project for restricted shared VPC."
-  value       = module.env.restricted_shared_vpc_project_id
+  value       = join("", module.env.restricted_shared_vpc_project_id)
 }
 
 output "env_secrets_project_id" {
   description = "Project for environment related secrets."
-  value       = module.env.env_secrets_project_id
+  value       = join("", module.env.env_secrets_project_id)
 }

--- a/2-environments/envs/production/variables.tf
+++ b/2-environments/envs/production/variables.tf
@@ -51,3 +51,19 @@ variable "folder_prefix" {
   type        = string
   default     = "fldr"
 }
+
+
+variable "enable_development" {
+  description = "To enable creation of the development environment."
+  type        = bool
+}
+
+variable "enable_non_production" {
+  description = "To enable creation of the non-production environment."
+  type        = bool
+}
+
+variable "enable_production" {
+  description = "To enable creation of the production environment."
+  type        = bool
+}

--- a/2-environments/terraform.example.tfvars
+++ b/2-environments/terraform.example.tfvars
@@ -25,3 +25,8 @@ monitoring_workspace_users = "gcp-monitoring-admins@example.com"
 // Optional - for an organization with existing projects or for development/validation.
 // Must be the same value used in previous steps.
 //parent_folder = "01234567890"
+
+// Enable or disable creation of each environment, to save on project quotas
+enable_development = true
+enable_non_production = false
+enable_production = false


### PR DESCRIPTION
In this PR:

- Added three toggles for each of the three environments to save on projects quota (by default, if the Terraform foundation is left as-is, you will need to have quotas lifted to at least 43 projects)
  - By default, `development` env is created (the toggle is set to `true`)
- Dynamic `output`s when `count` is set to `0`
  - See https://github.com/hashicorp/terraform/issues/23222#issuecomment-547462883