### PR TITLE
feat: toggle for enabling envs in 3-networks

### DIFF
--- a/3-networks/README.md
+++ b/3-networks/README.md
@@ -69,6 +69,16 @@ The purpose of this step is to:
 
    **Note:** Make sure that you use the same version of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
 
+### 💬 Projects quota
+
+If you do not have sufficient projects quota, we recommend that you deploy only the `development` environment. It is recommended to modify the following attributes in [`terraform.example.tfvars`](./terraform.example.tfvars):
+
+```
+enable_development = true
+enable_non_production = false
+enable_production = false
+```
+
 ### Troubleshooting
 
 Please refer to [troubleshooting](../docs/TROUBLESHOOTING.md) if you run into issues during this step.

--- a/3-networks/common.auto.example.tfvars
+++ b/3-networks/common.auto.example.tfvars
@@ -32,3 +32,8 @@ domain = "example.com."
 //enable_hub_and_spoke = true
 
 //enable_hub_and_spoke_transitivity = true
+
+// Enable or disable creation of each environment, to save on project quotas
+enable_development = true
+enable_non_production = false
+enable_production = false

--- a/3-networks/envs/development/main.tf
+++ b/3-networks/envs/development/main.tf
@@ -152,6 +152,7 @@ module "restricted_shared_vpc" {
 
 module "base_shared_vpc" {
   source                        = "../../modules/base_shared_vpc"
+  count                         = var.enable_development ? 1 : 0
   project_id                    = local.base_project_id
   environment_code              = local.environment_code
   private_service_cidr          = local.base_private_service_cidr

--- a/3-networks/envs/development/outputs.tf
+++ b/3-networks/envs/development/outputs.tf
@@ -14,90 +14,90 @@
  * limitations under the License.
  */
 
-/*********************
- Restricted Outputs
-*********************/
+# /*********************
+#  Restricted Outputs
+# *********************/
 
-output "restricted_host_project_id" {
-  value       = local.restricted_project_id
-  description = "The restricted host project ID"
-}
+# output "restricted_host_project_id" {
+#   value       = local.restricted_project_id
+#   description = "The restricted host project ID"
+# }
 
-output "restricted_network_name" {
-  value       = module.restricted_shared_vpc.network_name
-  description = "The name of the VPC being created"
-}
+# output "restricted_network_name" {
+#   value       = module.restricted_shared_vpc.network_name
+#   description = "The name of the VPC being created"
+# }
 
-output "restricted_network_self_link" {
-  value       = module.restricted_shared_vpc.network_self_link
-  description = "The URI of the VPC being created"
-}
+# output "restricted_network_self_link" {
+#   value       = module.restricted_shared_vpc.network_self_link
+#   description = "The URI of the VPC being created"
+# }
 
-output "restricted_subnets_names" {
-  value       = module.restricted_shared_vpc.subnets_names
-  description = "The names of the subnets being created"
-}
+# output "restricted_subnets_names" {
+#   value       = module.restricted_shared_vpc.subnets_names
+#   description = "The names of the subnets being created"
+# }
 
-output "restricted_subnets_ips" {
-  value       = module.restricted_shared_vpc.subnets_ips
-  description = "The IPs and CIDRs of the subnets being created"
-}
+# output "restricted_subnets_ips" {
+#   value       = module.restricted_shared_vpc.subnets_ips
+#   description = "The IPs and CIDRs of the subnets being created"
+# }
 
-output "restricted_subnets_self_links" {
-  value       = module.restricted_shared_vpc.subnets_self_links
-  description = "The self-links of subnets being created"
-}
+# output "restricted_subnets_self_links" {
+#   value       = module.restricted_shared_vpc.subnets_self_links
+#   description = "The self-links of subnets being created"
+# }
 
-output "restricted_subnets_secondary_ranges" {
-  value       = module.restricted_shared_vpc.subnets_secondary_ranges
-  description = "The secondary ranges associated with these subnets"
-}
+# output "restricted_subnets_secondary_ranges" {
+#   value       = module.restricted_shared_vpc.subnets_secondary_ranges
+#   description = "The secondary ranges associated with these subnets"
+# }
 
-output "restricted_access_level_name" {
-  value       = module.restricted_shared_vpc.access_level_name
-  description = "Access context manager access level name"
-}
+# output "restricted_access_level_name" {
+#   value       = module.restricted_shared_vpc.access_level_name
+#   description = "Access context manager access level name"
+# }
 
-output "restricted_service_perimeter_name" {
-  value       = module.restricted_shared_vpc.service_perimeter_name
-  description = "Access context manager service perimeter name"
-}
+# output "restricted_service_perimeter_name" {
+#   value       = module.restricted_shared_vpc.service_perimeter_name
+#   description = "Access context manager service perimeter name"
+# }
 
-/******************************************
- Private Outputs
-*****************************************/
+# /******************************************
+#  Private Outputs
+# *****************************************/
 
-output "base_host_project_id" {
-  value       = local.base_project_id
-  description = "The base host project ID"
-}
+# output "base_host_project_id" {
+#   value       = local.base_project_id
+#   description = "The base host project ID"
+# }
 
-output "base_network_name" {
-  value       = module.base_shared_vpc.network_name
-  description = "The name of the VPC being created"
-}
+# output "base_network_name" {
+#   value       = module.base_shared_vpc.network_name
+#   description = "The name of the VPC being created"
+# }
 
-output "base_network_self_link" {
-  value       = module.base_shared_vpc.network_self_link
-  description = "The URI of the VPC being created"
-}
+# output "base_network_self_link" {
+#   value       = module.base_shared_vpc.network_self_link
+#   description = "The URI of the VPC being created"
+# }
 
-output "base_subnets_names" {
-  value       = module.base_shared_vpc.subnets_names
-  description = "The names of the subnets being created"
-}
+# output "base_subnets_names" {
+#   value       = module.base_shared_vpc.subnets_names
+#   description = "The names of the subnets being created"
+# }
 
-output "base_subnets_ips" {
-  value       = module.base_shared_vpc.subnets_ips
-  description = "The IPs and CIDRs of the subnets being created"
-}
+# output "base_subnets_ips" {
+#   value       = module.base_shared_vpc.subnets_ips
+#   description = "The IPs and CIDRs of the subnets being created"
+# }
 
-output "base_subnets_self_links" {
-  value       = module.base_shared_vpc.subnets_self_links
-  description = "The self-links of subnets being created"
-}
+# output "base_subnets_self_links" {
+#   value       = module.base_shared_vpc.subnets_self_links
+#   description = "The self-links of subnets being created"
+# }
 
-output "base_subnets_secondary_ranges" {
-  value       = module.base_shared_vpc.subnets_secondary_ranges
-  description = "The secondary ranges associated with these subnets"
-}
+# output "base_subnets_secondary_ranges" {
+#   value       = module.base_shared_vpc.subnets_secondary_ranges
+#   description = "The secondary ranges associated with these subnets"
+# }

--- a/3-networks/envs/development/variables.tf
+++ b/3-networks/envs/development/variables.tf
@@ -145,3 +145,19 @@ variable "enable_hub_and_spoke_transitivity" {
   type        = bool
   default     = false
 }
+
+
+variable "enable_development" {
+  description = "To enable creation of the development environment."
+  type        = bool
+}
+
+variable "enable_non_production" {
+  description = "To enable creation of the non-production environment."
+  type        = bool
+}
+
+variable "enable_production" {
+  description = "To enable creation of the production environment."
+  type        = bool
+}

--- a/3-networks/envs/non-production/main.tf
+++ b/3-networks/envs/non-production/main.tf
@@ -96,6 +96,7 @@ data "google_projects" "base_host_project" {
 *****************************************/
 module "restricted_shared_vpc" {
   source                           = "../../modules/restricted_shared_vpc"
+  count                            = var.enable_non_production ? 1 : 0
   project_id                       = local.restricted_project_id
   project_number                   = local.restricted_project_number
   environment_code                 = local.environment_code

--- a/3-networks/envs/non-production/outputs.tf
+++ b/3-networks/envs/non-production/outputs.tf
@@ -14,90 +14,90 @@
  * limitations under the License.
  */
 
-/*********************
- Restricted Outputs
-*********************/
+# /*********************
+#  Restricted Outputs
+# *********************/
 
-output "restricted_host_project_id" {
-  value       = local.restricted_project_id
-  description = "The restricted host project ID"
-}
+# output "restricted_host_project_id" {
+#   value       = local.restricted_project_id
+#   description = "The restricted host project ID"
+# }
 
-output "restricted_network_name" {
-  value       = module.restricted_shared_vpc.network_name
-  description = "The name of the VPC being created"
-}
+# output "restricted_network_name" {
+#   value       = module.restricted_shared_vpc.network_name
+#   description = "The name of the VPC being created"
+# }
 
-output "restricted_network_self_link" {
-  value       = module.restricted_shared_vpc.network_self_link
-  description = "The URI of the VPC being created"
-}
+# output "restricted_network_self_link" {
+#   value       = module.restricted_shared_vpc.network_self_link
+#   description = "The URI of the VPC being created"
+# }
 
-output "restricted_subnets_names" {
-  value       = module.restricted_shared_vpc.subnets_names
-  description = "The names of the subnets being created"
-}
+# output "restricted_subnets_names" {
+#   value       = module.restricted_shared_vpc.subnets_names
+#   description = "The names of the subnets being created"
+# }
 
-output "restricted_subnets_ips" {
-  value       = module.restricted_shared_vpc.subnets_ips
-  description = "The IPs and CIDRs of the subnets being created"
-}
+# output "restricted_subnets_ips" {
+#   value       = module.restricted_shared_vpc.subnets_ips
+#   description = "The IPs and CIDRs of the subnets being created"
+# }
 
-output "restricted_subnets_self_links" {
-  value       = module.restricted_shared_vpc.subnets_self_links
-  description = "The self-links of subnets being created"
-}
+# output "restricted_subnets_self_links" {
+#   value       = module.restricted_shared_vpc.subnets_self_links
+#   description = "The self-links of subnets being created"
+# }
 
-output "restricted_subnets_secondary_ranges" {
-  value       = module.restricted_shared_vpc.subnets_secondary_ranges
-  description = "The secondary ranges associated with these subnets"
-}
+# output "restricted_subnets_secondary_ranges" {
+#   value       = module.restricted_shared_vpc.subnets_secondary_ranges
+#   description = "The secondary ranges associated with these subnets"
+# }
 
-output "restricted_access_level_name" {
-  value       = module.restricted_shared_vpc.access_level_name
-  description = "Access context manager access level name"
-}
+# output "restricted_access_level_name" {
+#   value       = module.restricted_shared_vpc.access_level_name
+#   description = "Access context manager access level name"
+# }
 
-output "restricted_service_perimeter_name" {
-  value       = module.restricted_shared_vpc.service_perimeter_name
-  description = "Access context manager service perimeter name"
-}
+# output "restricted_service_perimeter_name" {
+#   value       = module.restricted_shared_vpc.service_perimeter_name
+#   description = "Access context manager service perimeter name"
+# }
 
-/******************************************
- Private Outputs
-*****************************************/
+# /******************************************
+#  Private Outputs
+# *****************************************/
 
-output "base_host_project_id" {
-  value       = local.base_project_id
-  description = "The base host project ID"
-}
+# output "base_host_project_id" {
+#   value       = local.base_project_id
+#   description = "The base host project ID"
+# }
 
-output "base_network_name" {
-  value       = module.base_shared_vpc.network_name
-  description = "The name of the VPC being created"
-}
+# output "base_network_name" {
+#   value       = module.base_shared_vpc.network_name
+#   description = "The name of the VPC being created"
+# }
 
-output "base_network_self_link" {
-  value       = module.base_shared_vpc.network_self_link
-  description = "The URI of the VPC being created"
-}
+# output "base_network_self_link" {
+#   value       = module.base_shared_vpc.network_self_link
+#   description = "The URI of the VPC being created"
+# }
 
-output "base_subnets_names" {
-  value       = module.base_shared_vpc.subnets_names
-  description = "The names of the subnets being created"
-}
+# output "base_subnets_names" {
+#   value       = module.base_shared_vpc.subnets_names
+#   description = "The names of the subnets being created"
+# }
 
-output "base_subnets_ips" {
-  value       = module.base_shared_vpc.subnets_ips
-  description = "The IPs and CIDRs of the subnets being created"
-}
+# output "base_subnets_ips" {
+#   value       = module.base_shared_vpc.subnets_ips
+#   description = "The IPs and CIDRs of the subnets being created"
+# }
 
-output "base_subnets_self_links" {
-  value       = module.base_shared_vpc.subnets_self_links
-  description = "The self-links of subnets being created"
-}
+# output "base_subnets_self_links" {
+#   value       = module.base_shared_vpc.subnets_self_links
+#   description = "The self-links of subnets being created"
+# }
 
-output "base_subnets_secondary_ranges" {
-  value       = module.base_shared_vpc.subnets_secondary_ranges
-  description = "The secondary ranges associated with these subnets"
-}
+# output "base_subnets_secondary_ranges" {
+#   value       = module.base_shared_vpc.subnets_secondary_ranges
+#   description = "The secondary ranges associated with these subnets"
+# }

--- a/3-networks/envs/non-production/variables.tf
+++ b/3-networks/envs/non-production/variables.tf
@@ -145,3 +145,19 @@ variable "enable_hub_and_spoke_transitivity" {
   type        = bool
   default     = false
 }
+
+
+variable "enable_development" {
+  description = "To enable creation of the development environment."
+  type        = bool
+}
+
+variable "enable_non_production" {
+  description = "To enable creation of the non-production environment."
+  type        = bool
+}
+
+variable "enable_production" {
+  description = "To enable creation of the production environment."
+  type        = bool
+}

--- a/3-networks/envs/production/main.tf
+++ b/3-networks/envs/production/main.tf
@@ -96,6 +96,7 @@ data "google_projects" "base_host_project" {
 *****************************************/
 module "restricted_shared_vpc" {
   source                           = "../../modules/restricted_shared_vpc"
+  count                            = var.enable_production ? 1 : 0
   project_id                       = local.restricted_project_id
   project_number                   = local.restricted_project_number
   environment_code                 = local.environment_code

--- a/3-networks/envs/production/outputs.tf
+++ b/3-networks/envs/production/outputs.tf
@@ -14,90 +14,90 @@
  * limitations under the License.
  */
 
-/*********************
- Restricted Outputs
-*********************/
+# /*********************
+#  Restricted Outputs
+# *********************/
 
-output "restricted_host_project_id" {
-  value       = local.restricted_project_id
-  description = "The restricted host project ID"
-}
+# output "restricted_host_project_id" {
+#   value       = local.restricted_project_id
+#   description = "The restricted host project ID"
+# }
 
-output "restricted_network_name" {
-  value       = module.restricted_shared_vpc.network_name
-  description = "The name of the VPC being created"
-}
+# output "restricted_network_name" {
+#   value       = module.restricted_shared_vpc.network_name
+#   description = "The name of the VPC being created"
+# }
 
-output "restricted_network_self_link" {
-  value       = module.restricted_shared_vpc.network_self_link
-  description = "The URI of the VPC being created"
-}
+# output "restricted_network_self_link" {
+#   value       = module.restricted_shared_vpc.network_self_link
+#   description = "The URI of the VPC being created"
+# }
 
-output "restricted_subnets_names" {
-  value       = module.restricted_shared_vpc.subnets_names
-  description = "The names of the subnets being created"
-}
+# output "restricted_subnets_names" {
+#   value       = module.restricted_shared_vpc.subnets_names
+#   description = "The names of the subnets being created"
+# }
 
-output "restricted_subnets_ips" {
-  value       = module.restricted_shared_vpc.subnets_ips
-  description = "The IPs and CIDRs of the subnets being created"
-}
+# output "restricted_subnets_ips" {
+#   value       = module.restricted_shared_vpc.subnets_ips
+#   description = "The IPs and CIDRs of the subnets being created"
+# }
 
-output "restricted_subnets_self_links" {
-  value       = module.restricted_shared_vpc.subnets_self_links
-  description = "The self-links of subnets being created"
-}
+# output "restricted_subnets_self_links" {
+#   value       = module.restricted_shared_vpc.subnets_self_links
+#   description = "The self-links of subnets being created"
+# }
 
-output "restricted_subnets_secondary_ranges" {
-  value       = module.restricted_shared_vpc.subnets_secondary_ranges
-  description = "The secondary ranges associated with these subnets"
-}
+# output "restricted_subnets_secondary_ranges" {
+#   value       = module.restricted_shared_vpc.subnets_secondary_ranges
+#   description = "The secondary ranges associated with these subnets"
+# }
 
-output "restricted_access_level_name" {
-  value       = module.restricted_shared_vpc.access_level_name
-  description = "Access context manager access level name"
-}
+# output "restricted_access_level_name" {
+#   value       = module.restricted_shared_vpc.access_level_name
+#   description = "Access context manager access level name"
+# }
 
-output "restricted_service_perimeter_name" {
-  value       = module.restricted_shared_vpc.service_perimeter_name
-  description = "Access context manager service perimeter name"
-}
+# output "restricted_service_perimeter_name" {
+#   value       = module.restricted_shared_vpc.service_perimeter_name
+#   description = "Access context manager service perimeter name"
+# }
 
-/******************************************
- Private Outputs
-*****************************************/
+# /******************************************
+#  Private Outputs
+# *****************************************/
 
-output "base_host_project_id" {
-  value       = local.base_project_id
-  description = "The base host project ID"
-}
+# output "base_host_project_id" {
+#   value       = local.base_project_id
+#   description = "The base host project ID"
+# }
 
-output "base_network_name" {
-  value       = module.base_shared_vpc.network_name
-  description = "The name of the VPC being created"
-}
+# output "base_network_name" {
+#   value       = module.base_shared_vpc.network_name
+#   description = "The name of the VPC being created"
+# }
 
-output "base_network_self_link" {
-  value       = module.base_shared_vpc.network_self_link
-  description = "The URI of the VPC being created"
-}
+# output "base_network_self_link" {
+#   value       = module.base_shared_vpc.network_self_link
+#   description = "The URI of the VPC being created"
+# }
 
-output "base_subnets_names" {
-  value       = module.base_shared_vpc.subnets_names
-  description = "The names of the subnets being created"
-}
+# output "base_subnets_names" {
+#   value       = module.base_shared_vpc.subnets_names
+#   description = "The names of the subnets being created"
+# }
 
-output "base_subnets_ips" {
-  value       = module.base_shared_vpc.subnets_ips
-  description = "The IPs and CIDRs of the subnets being created"
-}
+# output "base_subnets_ips" {
+#   value       = module.base_shared_vpc.subnets_ips
+#   description = "The IPs and CIDRs of the subnets being created"
+# }
 
-output "base_subnets_self_links" {
-  value       = module.base_shared_vpc.subnets_self_links
-  description = "The self-links of subnets being created"
-}
+# output "base_subnets_self_links" {
+#   value       = module.base_shared_vpc.subnets_self_links
+#   description = "The self-links of subnets being created"
+# }
 
-output "base_subnets_secondary_ranges" {
-  value       = module.base_shared_vpc.subnets_secondary_ranges
-  description = "The secondary ranges associated with these subnets"
-}
+# output "base_subnets_secondary_ranges" {
+#   value       = module.base_shared_vpc.subnets_secondary_ranges
+#   description = "The secondary ranges associated with these subnets"
+# }

--- a/3-networks/envs/production/variables.tf
+++ b/3-networks/envs/production/variables.tf
@@ -145,3 +145,19 @@ variable "enable_hub_and_spoke_transitivity" {
   type        = bool
   default     = false
 }
+
+
+variable "enable_development" {
+  description = "To enable creation of the development environment."
+  type        = bool
+}
+
+variable "enable_non_production" {
+  description = "To enable creation of the non-production environment."
+  type        = bool
+}
+
+variable "enable_production" {
+  description = "To enable creation of the production environment."
+  type        = bool
+}


### PR DESCRIPTION
In this PR

- Added three toggles for each of the three environments to save on projects quota (by default, if the Terraform foundation is left as-is, you will need to have quotas lifted to at least 43 projects if followed through)
  - By default, `development` env is created (the toggle is set to `true`)
- Removed `outputs.tf` because somehow the solution for `output`s when `count` is set to `0` doesn't work
  - See https://github.com/hashicorp/terraform/issues/23222#issuecomment-547462883
- This PR is similar to https://github.com/bankoncloud/terraform-example-foundation-sgmy-fsi/pull/22