### PR TITLE
fix: remove toggles for 2-environments and 3-networks

### DIFF
--- a/2-environments/README.md
+++ b/2-environments/README.md
@@ -62,16 +62,6 @@ The purpose of this step is to setup development, non-production, and production
 
 Please refer to [troubleshooting](../docs/TROUBLESHOOTING.md) if you run into issues during this step.
 
-### 💬 Projects quota
-
-If you do not have sufficient projects quota, we recommend that you deploy only the `development` environment. It is recommended to modify the following attributes in [`terraform.example.tfvars`](./terraform.example.tfvars):
-
-```
-enable_development = true
-enable_non_production = false
-enable_production = false
-```
-
 ## Usage
 
 **Note:** If you are using MacOS, replace `cp -RT` with `cp -R` in the relevant

--- a/2-environments/envs/development/README.md
+++ b/2-environments/envs/development/README.md
@@ -10,7 +10,6 @@
 | parent\_folder | Optional - for an organization with existing projects or for development/validation. It will place all the example foundation resources under the provided folder instead of the root organization. The value is the numeric folder ID. The folder must already exist. Must be the same value used in previous step. | `string` | `""` | no |
 | project\_prefix | Name prefix to use for projects created. Should be the same in all steps. Max size is 3 characters. | `string` | `"prj"` | no |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | `string` | n/a | yes |
-| enable\_development | To enable creation of the development environment. | `bool` | n/a | yes |
 
 ## Outputs
 

--- a/2-environments/envs/development/main.tf
+++ b/2-environments/envs/development/main.tf
@@ -17,8 +17,6 @@
 module "env" {
   source = "../../modules/env_baseline"
 
-  count  = var.enable_development ? 1 : 0
-
   env              = "development"
   environment_code = "d"
 

--- a/2-environments/envs/development/outputs.tf
+++ b/2-environments/envs/development/outputs.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "env_folder" {
+  description = "Environment folder created under parent."
+  value       = module.env.env_folder
+}
+
+output "monitoring_project_id" {
+  description = "Project for monitoring infra."
+  value       = module.env.monitoring_project_id
+}
+
+output "base_shared_vpc_project_id" {
+  description = "Project for base shared VPC."
+  value       = module.env.base_shared_vpc_project_id
+}
+
+output "restricted_shared_vpc_project_id" {
+  description = "Project for restricted shared VPC."
+  value       = module.env.restricted_shared_vpc_project_id
+}
+
+output "env_secrets_project_id" {
+  description = "Project for environment related secrets."
+  value       = module.env.env_secrets_project_id
+}

--- a/2-environments/envs/development/variables.tf
+++ b/2-environments/envs/development/variables.tf
@@ -51,19 +51,3 @@ variable "folder_prefix" {
   type        = string
   default     = "fldr"
 }
-
-
-variable "enable_development" {
-  description = "To enable creation of the development environment."
-  type        = bool
-}
-
-variable "enable_non_production" {
-  description = "To enable creation of the non-production environment."
-  type        = bool
-}
-
-variable "enable_production" {
-  description = "To enable creation of the production environment."
-  type        = bool
-}

--- a/2-environments/envs/non-production/README.md
+++ b/2-environments/envs/non-production/README.md
@@ -10,7 +10,6 @@
 | parent\_folder | Optional - for an organization with existing projects or for development/validation. It will place all the example foundation resources under the provided folder instead of the root organization. The value is the numeric folder ID. The folder must already exist. Must be the same value used in previous step. | `string` | `""` | no |
 | project\_prefix | Name prefix to use for projects created. Should be the same in all steps. Max size is 3 characters. | `string` | `"prj"` | no |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | `string` | n/a | yes |
-| enable\_non\_production | To enable creation of the non-production environment. | `bool` | n/a | yes |
 
 ## Outputs
 

--- a/2-environments/envs/non-production/main.tf
+++ b/2-environments/envs/non-production/main.tf
@@ -17,8 +17,6 @@
 module "env" {
   source = "../../modules/env_baseline"
 
-  count  = var.enable_non_production ? 1 : 0
-
   env              = "non-production"
   environment_code = "n"
 

--- a/2-environments/envs/non-production/outputs.tf
+++ b/2-environments/envs/non-production/outputs.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "env_folder" {
+  description = "Environment folder created under parent."
+  value       = module.env.env_folder
+}
+
+output "monitoring_project_id" {
+  description = "Project for monitoring infra."
+  value       = module.env.monitoring_project_id
+}
+
+output "base_shared_vpc_project_id" {
+  description = "Project for base shared VPC."
+  value       = module.env.base_shared_vpc_project_id
+}
+
+output "restricted_shared_vpc_project_id" {
+  description = "Project for restricted shared VPC."
+  value       = module.env.restricted_shared_vpc_project_id
+}
+
+output "env_secrets_project_id" {
+  description = "Project for environment related secrets."
+  value       = module.env.env_secrets_project_id
+}

--- a/2-environments/envs/non-production/variables.tf
+++ b/2-environments/envs/non-production/variables.tf
@@ -51,19 +51,3 @@ variable "folder_prefix" {
   type        = string
   default     = "fldr"
 }
-
-
-variable "enable_development" {
-  description = "To enable creation of the development environment."
-  type        = bool
-}
-
-variable "enable_non_production" {
-  description = "To enable creation of the non-production environment."
-  type        = bool
-}
-
-variable "enable_production" {
-  description = "To enable creation of the production environment."
-  type        = bool
-}

--- a/2-environments/envs/production/README.md
+++ b/2-environments/envs/production/README.md
@@ -10,7 +10,6 @@
 | parent\_folder | Optional - for an organization with existing projects or for development/validation. It will place all the example foundation resources under the provided folder instead of the root organization. The value is the numeric folder ID. The folder must already exist. Must be the same value used in previous step. | `string` | `""` | no |
 | project\_prefix | Name prefix to use for projects created. Should be the same in all steps. Max size is 3 characters. | `string` | `"prj"` | no |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | `string` | n/a | yes |
-| enable\_production | To enable creation of the production environment. | `bool` | n/a | yes |
 
 ## Outputs
 

--- a/2-environments/envs/production/main.tf
+++ b/2-environments/envs/production/main.tf
@@ -17,8 +17,6 @@
 module "env" {
   source = "../../modules/env_baseline"
 
-  count  = var.enable_production ? 1 : 0
-
   env              = "production"
   environment_code = "p"
 

--- a/2-environments/envs/production/outputs.tf
+++ b/2-environments/envs/production/outputs.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "env_folder" {
+  description = "Environment folder created under parent."
+  value       = module.env.env_folder
+}
+
+output "monitoring_project_id" {
+  description = "Project for monitoring infra."
+  value       = module.env.monitoring_project_id
+}
+
+output "base_shared_vpc_project_id" {
+  description = "Project for base shared VPC."
+  value       = module.env.base_shared_vpc_project_id
+}
+
+output "restricted_shared_vpc_project_id" {
+  description = "Project for restricted shared VPC."
+  value       = module.env.restricted_shared_vpc_project_id
+}
+
+output "env_secrets_project_id" {
+  description = "Project for environment related secrets."
+  value       = module.env.env_secrets_project_id
+}

--- a/2-environments/envs/production/variables.tf
+++ b/2-environments/envs/production/variables.tf
@@ -51,19 +51,3 @@ variable "folder_prefix" {
   type        = string
   default     = "fldr"
 }
-
-
-variable "enable_development" {
-  description = "To enable creation of the development environment."
-  type        = bool
-}
-
-variable "enable_non_production" {
-  description = "To enable creation of the non-production environment."
-  type        = bool
-}
-
-variable "enable_production" {
-  description = "To enable creation of the production environment."
-  type        = bool
-}

--- a/2-environments/terraform.example.tfvars
+++ b/2-environments/terraform.example.tfvars
@@ -25,8 +25,3 @@ monitoring_workspace_users = "gcp-monitoring-admins@example.com"
 // Optional - for an organization with existing projects or for development/validation.
 // Must be the same value used in previous steps.
 //parent_folder = "01234567890"
-
-// Enable or disable creation of each environment, to save on project quotas
-enable_development = true
-enable_non_production = false
-enable_production = false

--- a/3-networks/README.md
+++ b/3-networks/README.md
@@ -69,16 +69,6 @@ The purpose of this step is to:
 
    **Note:** Make sure that you use the same version of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
 
-### 💬 Projects quota
-
-If you do not have sufficient projects quota, we recommend that you deploy only the `development` environment. It is recommended to modify the following attributes in [`terraform.example.tfvars`](./terraform.example.tfvars):
-
-```
-enable_development = true
-enable_non_production = false
-enable_production = false
-```
-
 ### Troubleshooting
 
 Please refer to [troubleshooting](../docs/TROUBLESHOOTING.md) if you run into issues during this step.

--- a/3-networks/common.auto.example.tfvars
+++ b/3-networks/common.auto.example.tfvars
@@ -32,8 +32,3 @@ domain = "example.com."
 //enable_hub_and_spoke = true
 
 //enable_hub_and_spoke_transitivity = true
-
-// Enable or disable creation of each environment, to save on project quotas
-enable_development = true
-enable_non_production = false
-enable_production = false

--- a/3-networks/envs/development/main.tf
+++ b/3-networks/envs/development/main.tf
@@ -152,7 +152,6 @@ module "restricted_shared_vpc" {
 
 module "base_shared_vpc" {
   source                        = "../../modules/base_shared_vpc"
-  count                         = var.enable_development ? 1 : 0
   project_id                    = local.base_project_id
   environment_code              = local.environment_code
   private_service_cidr          = local.base_private_service_cidr

--- a/3-networks/envs/development/outputs.tf
+++ b/3-networks/envs/development/outputs.tf
@@ -14,90 +14,90 @@
  * limitations under the License.
  */
 
-# /*********************
-#  Restricted Outputs
-# *********************/
+/*********************
+ Restricted Outputs
+*********************/
 
-# output "restricted_host_project_id" {
-#   value       = local.restricted_project_id
-#   description = "The restricted host project ID"
-# }
+output "restricted_host_project_id" {
+  value       = local.restricted_project_id
+  description = "The restricted host project ID"
+}
 
-# output "restricted_network_name" {
-#   value       = module.restricted_shared_vpc.network_name
-#   description = "The name of the VPC being created"
-# }
+output "restricted_network_name" {
+  value       = module.restricted_shared_vpc.network_name
+  description = "The name of the VPC being created"
+}
 
-# output "restricted_network_self_link" {
-#   value       = module.restricted_shared_vpc.network_self_link
-#   description = "The URI of the VPC being created"
-# }
+output "restricted_network_self_link" {
+  value       = module.restricted_shared_vpc.network_self_link
+  description = "The URI of the VPC being created"
+}
 
-# output "restricted_subnets_names" {
-#   value       = module.restricted_shared_vpc.subnets_names
-#   description = "The names of the subnets being created"
-# }
+output "restricted_subnets_names" {
+  value       = module.restricted_shared_vpc.subnets_names
+  description = "The names of the subnets being created"
+}
 
-# output "restricted_subnets_ips" {
-#   value       = module.restricted_shared_vpc.subnets_ips
-#   description = "The IPs and CIDRs of the subnets being created"
-# }
+output "restricted_subnets_ips" {
+  value       = module.restricted_shared_vpc.subnets_ips
+  description = "The IPs and CIDRs of the subnets being created"
+}
 
-# output "restricted_subnets_self_links" {
-#   value       = module.restricted_shared_vpc.subnets_self_links
-#   description = "The self-links of subnets being created"
-# }
+output "restricted_subnets_self_links" {
+  value       = module.restricted_shared_vpc.subnets_self_links
+  description = "The self-links of subnets being created"
+}
 
-# output "restricted_subnets_secondary_ranges" {
-#   value       = module.restricted_shared_vpc.subnets_secondary_ranges
-#   description = "The secondary ranges associated with these subnets"
-# }
+output "restricted_subnets_secondary_ranges" {
+  value       = module.restricted_shared_vpc.subnets_secondary_ranges
+  description = "The secondary ranges associated with these subnets"
+}
 
-# output "restricted_access_level_name" {
-#   value       = module.restricted_shared_vpc.access_level_name
-#   description = "Access context manager access level name"
-# }
+output "restricted_access_level_name" {
+  value       = module.restricted_shared_vpc.access_level_name
+  description = "Access context manager access level name"
+}
 
-# output "restricted_service_perimeter_name" {
-#   value       = module.restricted_shared_vpc.service_perimeter_name
-#   description = "Access context manager service perimeter name"
-# }
+output "restricted_service_perimeter_name" {
+  value       = module.restricted_shared_vpc.service_perimeter_name
+  description = "Access context manager service perimeter name"
+}
 
-# /******************************************
-#  Private Outputs
-# *****************************************/
+/******************************************
+ Private Outputs
+*****************************************/
 
-# output "base_host_project_id" {
-#   value       = local.base_project_id
-#   description = "The base host project ID"
-# }
+output "base_host_project_id" {
+  value       = local.base_project_id
+  description = "The base host project ID"
+}
 
-# output "base_network_name" {
-#   value       = module.base_shared_vpc.network_name
-#   description = "The name of the VPC being created"
-# }
+output "base_network_name" {
+  value       = module.base_shared_vpc.network_name
+  description = "The name of the VPC being created"
+}
 
-# output "base_network_self_link" {
-#   value       = module.base_shared_vpc.network_self_link
-#   description = "The URI of the VPC being created"
-# }
+output "base_network_self_link" {
+  value       = module.base_shared_vpc.network_self_link
+  description = "The URI of the VPC being created"
+}
 
-# output "base_subnets_names" {
-#   value       = module.base_shared_vpc.subnets_names
-#   description = "The names of the subnets being created"
-# }
+output "base_subnets_names" {
+  value       = module.base_shared_vpc.subnets_names
+  description = "The names of the subnets being created"
+}
 
-# output "base_subnets_ips" {
-#   value       = module.base_shared_vpc.subnets_ips
-#   description = "The IPs and CIDRs of the subnets being created"
-# }
+output "base_subnets_ips" {
+  value       = module.base_shared_vpc.subnets_ips
+  description = "The IPs and CIDRs of the subnets being created"
+}
 
-# output "base_subnets_self_links" {
-#   value       = module.base_shared_vpc.subnets_self_links
-#   description = "The self-links of subnets being created"
-# }
+output "base_subnets_self_links" {
+  value       = module.base_shared_vpc.subnets_self_links
+  description = "The self-links of subnets being created"
+}
 
-# output "base_subnets_secondary_ranges" {
-#   value       = module.base_shared_vpc.subnets_secondary_ranges
-#   description = "The secondary ranges associated with these subnets"
-# }
+output "base_subnets_secondary_ranges" {
+  value       = module.base_shared_vpc.subnets_secondary_ranges
+  description = "The secondary ranges associated with these subnets"
+}

--- a/3-networks/envs/development/variables.tf
+++ b/3-networks/envs/development/variables.tf
@@ -145,19 +145,3 @@ variable "enable_hub_and_spoke_transitivity" {
   type        = bool
   default     = false
 }
-
-
-variable "enable_development" {
-  description = "To enable creation of the development environment."
-  type        = bool
-}
-
-variable "enable_non_production" {
-  description = "To enable creation of the non-production environment."
-  type        = bool
-}
-
-variable "enable_production" {
-  description = "To enable creation of the production environment."
-  type        = bool
-}

--- a/3-networks/envs/non-production/main.tf
+++ b/3-networks/envs/non-production/main.tf
@@ -96,7 +96,6 @@ data "google_projects" "base_host_project" {
 *****************************************/
 module "restricted_shared_vpc" {
   source                           = "../../modules/restricted_shared_vpc"
-  count                            = var.enable_non_production ? 1 : 0
   project_id                       = local.restricted_project_id
   project_number                   = local.restricted_project_number
   environment_code                 = local.environment_code

--- a/3-networks/envs/non-production/outputs.tf
+++ b/3-networks/envs/non-production/outputs.tf
@@ -14,90 +14,90 @@
  * limitations under the License.
  */
 
-# /*********************
-#  Restricted Outputs
-# *********************/
+/*********************
+ Restricted Outputs
+*********************/
 
-# output "restricted_host_project_id" {
-#   value       = local.restricted_project_id
-#   description = "The restricted host project ID"
-# }
+output "restricted_host_project_id" {
+  value       = local.restricted_project_id
+  description = "The restricted host project ID"
+}
 
-# output "restricted_network_name" {
-#   value       = module.restricted_shared_vpc.network_name
-#   description = "The name of the VPC being created"
-# }
+output "restricted_network_name" {
+  value       = module.restricted_shared_vpc.network_name
+  description = "The name of the VPC being created"
+}
 
-# output "restricted_network_self_link" {
-#   value       = module.restricted_shared_vpc.network_self_link
-#   description = "The URI of the VPC being created"
-# }
+output "restricted_network_self_link" {
+  value       = module.restricted_shared_vpc.network_self_link
+  description = "The URI of the VPC being created"
+}
 
-# output "restricted_subnets_names" {
-#   value       = module.restricted_shared_vpc.subnets_names
-#   description = "The names of the subnets being created"
-# }
+output "restricted_subnets_names" {
+  value       = module.restricted_shared_vpc.subnets_names
+  description = "The names of the subnets being created"
+}
 
-# output "restricted_subnets_ips" {
-#   value       = module.restricted_shared_vpc.subnets_ips
-#   description = "The IPs and CIDRs of the subnets being created"
-# }
+output "restricted_subnets_ips" {
+  value       = module.restricted_shared_vpc.subnets_ips
+  description = "The IPs and CIDRs of the subnets being created"
+}
 
-# output "restricted_subnets_self_links" {
-#   value       = module.restricted_shared_vpc.subnets_self_links
-#   description = "The self-links of subnets being created"
-# }
+output "restricted_subnets_self_links" {
+  value       = module.restricted_shared_vpc.subnets_self_links
+  description = "The self-links of subnets being created"
+}
 
-# output "restricted_subnets_secondary_ranges" {
-#   value       = module.restricted_shared_vpc.subnets_secondary_ranges
-#   description = "The secondary ranges associated with these subnets"
-# }
+output "restricted_subnets_secondary_ranges" {
+  value       = module.restricted_shared_vpc.subnets_secondary_ranges
+  description = "The secondary ranges associated with these subnets"
+}
 
-# output "restricted_access_level_name" {
-#   value       = module.restricted_shared_vpc.access_level_name
-#   description = "Access context manager access level name"
-# }
+output "restricted_access_level_name" {
+  value       = module.restricted_shared_vpc.access_level_name
+  description = "Access context manager access level name"
+}
 
-# output "restricted_service_perimeter_name" {
-#   value       = module.restricted_shared_vpc.service_perimeter_name
-#   description = "Access context manager service perimeter name"
-# }
+output "restricted_service_perimeter_name" {
+  value       = module.restricted_shared_vpc.service_perimeter_name
+  description = "Access context manager service perimeter name"
+}
 
-# /******************************************
-#  Private Outputs
-# *****************************************/
+/******************************************
+ Private Outputs
+*****************************************/
 
-# output "base_host_project_id" {
-#   value       = local.base_project_id
-#   description = "The base host project ID"
-# }
+output "base_host_project_id" {
+  value       = local.base_project_id
+  description = "The base host project ID"
+}
 
-# output "base_network_name" {
-#   value       = module.base_shared_vpc.network_name
-#   description = "The name of the VPC being created"
-# }
+output "base_network_name" {
+  value       = module.base_shared_vpc.network_name
+  description = "The name of the VPC being created"
+}
 
-# output "base_network_self_link" {
-#   value       = module.base_shared_vpc.network_self_link
-#   description = "The URI of the VPC being created"
-# }
+output "base_network_self_link" {
+  value       = module.base_shared_vpc.network_self_link
+  description = "The URI of the VPC being created"
+}
 
-# output "base_subnets_names" {
-#   value       = module.base_shared_vpc.subnets_names
-#   description = "The names of the subnets being created"
-# }
+output "base_subnets_names" {
+  value       = module.base_shared_vpc.subnets_names
+  description = "The names of the subnets being created"
+}
 
-# output "base_subnets_ips" {
-#   value       = module.base_shared_vpc.subnets_ips
-#   description = "The IPs and CIDRs of the subnets being created"
-# }
+output "base_subnets_ips" {
+  value       = module.base_shared_vpc.subnets_ips
+  description = "The IPs and CIDRs of the subnets being created"
+}
 
-# output "base_subnets_self_links" {
-#   value       = module.base_shared_vpc.subnets_self_links
-#   description = "The self-links of subnets being created"
-# }
+output "base_subnets_self_links" {
+  value       = module.base_shared_vpc.subnets_self_links
+  description = "The self-links of subnets being created"
+}
 
-# output "base_subnets_secondary_ranges" {
-#   value       = module.base_shared_vpc.subnets_secondary_ranges
-#   description = "The secondary ranges associated with these subnets"
-# }
+output "base_subnets_secondary_ranges" {
+  value       = module.base_shared_vpc.subnets_secondary_ranges
+  description = "The secondary ranges associated with these subnets"
+}

--- a/3-networks/envs/non-production/variables.tf
+++ b/3-networks/envs/non-production/variables.tf
@@ -138,26 +138,10 @@ variable "preactivate_partner_interconnect" {
   description = "Preactivate Partner Interconnect VLAN attachment in the environment."
   type        = bool
   default     = false
-
 }
+
 variable "enable_hub_and_spoke_transitivity" {
   description = "Enable transitivity via gateway VMs on Hub-and-Spoke architecture."
   type        = bool
   default     = false
-}
-
-
-variable "enable_development" {
-  description = "To enable creation of the development environment."
-  type        = bool
-}
-
-variable "enable_non_production" {
-  description = "To enable creation of the non-production environment."
-  type        = bool
-}
-
-variable "enable_production" {
-  description = "To enable creation of the production environment."
-  type        = bool
 }

--- a/3-networks/envs/production/main.tf
+++ b/3-networks/envs/production/main.tf
@@ -96,7 +96,6 @@ data "google_projects" "base_host_project" {
 *****************************************/
 module "restricted_shared_vpc" {
   source                           = "../../modules/restricted_shared_vpc"
-  count                            = var.enable_production ? 1 : 0
   project_id                       = local.restricted_project_id
   project_number                   = local.restricted_project_number
   environment_code                 = local.environment_code

--- a/3-networks/envs/production/outputs.tf
+++ b/3-networks/envs/production/outputs.tf
@@ -14,90 +14,90 @@
  * limitations under the License.
  */
 
-# /*********************
-#  Restricted Outputs
-# *********************/
+/*********************
+ Restricted Outputs
+*********************/
 
-# output "restricted_host_project_id" {
-#   value       = local.restricted_project_id
-#   description = "The restricted host project ID"
-# }
+output "restricted_host_project_id" {
+  value       = local.restricted_project_id
+  description = "The restricted host project ID"
+}
 
-# output "restricted_network_name" {
-#   value       = module.restricted_shared_vpc.network_name
-#   description = "The name of the VPC being created"
-# }
+output "restricted_network_name" {
+  value       = module.restricted_shared_vpc.network_name
+  description = "The name of the VPC being created"
+}
 
-# output "restricted_network_self_link" {
-#   value       = module.restricted_shared_vpc.network_self_link
-#   description = "The URI of the VPC being created"
-# }
+output "restricted_network_self_link" {
+  value       = module.restricted_shared_vpc.network_self_link
+  description = "The URI of the VPC being created"
+}
 
-# output "restricted_subnets_names" {
-#   value       = module.restricted_shared_vpc.subnets_names
-#   description = "The names of the subnets being created"
-# }
+output "restricted_subnets_names" {
+  value       = module.restricted_shared_vpc.subnets_names
+  description = "The names of the subnets being created"
+}
 
-# output "restricted_subnets_ips" {
-#   value       = module.restricted_shared_vpc.subnets_ips
-#   description = "The IPs and CIDRs of the subnets being created"
-# }
+output "restricted_subnets_ips" {
+  value       = module.restricted_shared_vpc.subnets_ips
+  description = "The IPs and CIDRs of the subnets being created"
+}
 
-# output "restricted_subnets_self_links" {
-#   value       = module.restricted_shared_vpc.subnets_self_links
-#   description = "The self-links of subnets being created"
-# }
+output "restricted_subnets_self_links" {
+  value       = module.restricted_shared_vpc.subnets_self_links
+  description = "The self-links of subnets being created"
+}
 
-# output "restricted_subnets_secondary_ranges" {
-#   value       = module.restricted_shared_vpc.subnets_secondary_ranges
-#   description = "The secondary ranges associated with these subnets"
-# }
+output "restricted_subnets_secondary_ranges" {
+  value       = module.restricted_shared_vpc.subnets_secondary_ranges
+  description = "The secondary ranges associated with these subnets"
+}
 
-# output "restricted_access_level_name" {
-#   value       = module.restricted_shared_vpc.access_level_name
-#   description = "Access context manager access level name"
-# }
+output "restricted_access_level_name" {
+  value       = module.restricted_shared_vpc.access_level_name
+  description = "Access context manager access level name"
+}
 
-# output "restricted_service_perimeter_name" {
-#   value       = module.restricted_shared_vpc.service_perimeter_name
-#   description = "Access context manager service perimeter name"
-# }
+output "restricted_service_perimeter_name" {
+  value       = module.restricted_shared_vpc.service_perimeter_name
+  description = "Access context manager service perimeter name"
+}
 
-# /******************************************
-#  Private Outputs
-# *****************************************/
+/******************************************
+ Private Outputs
+*****************************************/
 
-# output "base_host_project_id" {
-#   value       = local.base_project_id
-#   description = "The base host project ID"
-# }
+output "base_host_project_id" {
+  value       = local.base_project_id
+  description = "The base host project ID"
+}
 
-# output "base_network_name" {
-#   value       = module.base_shared_vpc.network_name
-#   description = "The name of the VPC being created"
-# }
+output "base_network_name" {
+  value       = module.base_shared_vpc.network_name
+  description = "The name of the VPC being created"
+}
 
-# output "base_network_self_link" {
-#   value       = module.base_shared_vpc.network_self_link
-#   description = "The URI of the VPC being created"
-# }
+output "base_network_self_link" {
+  value       = module.base_shared_vpc.network_self_link
+  description = "The URI of the VPC being created"
+}
 
-# output "base_subnets_names" {
-#   value       = module.base_shared_vpc.subnets_names
-#   description = "The names of the subnets being created"
-# }
+output "base_subnets_names" {
+  value       = module.base_shared_vpc.subnets_names
+  description = "The names of the subnets being created"
+}
 
-# output "base_subnets_ips" {
-#   value       = module.base_shared_vpc.subnets_ips
-#   description = "The IPs and CIDRs of the subnets being created"
-# }
+output "base_subnets_ips" {
+  value       = module.base_shared_vpc.subnets_ips
+  description = "The IPs and CIDRs of the subnets being created"
+}
 
-# output "base_subnets_self_links" {
-#   value       = module.base_shared_vpc.subnets_self_links
-#   description = "The self-links of subnets being created"
-# }
+output "base_subnets_self_links" {
+  value       = module.base_shared_vpc.subnets_self_links
+  description = "The self-links of subnets being created"
+}
 
-# output "base_subnets_secondary_ranges" {
-#   value       = module.base_shared_vpc.subnets_secondary_ranges
-#   description = "The secondary ranges associated with these subnets"
-# }
+output "base_subnets_secondary_ranges" {
+  value       = module.base_shared_vpc.subnets_secondary_ranges
+  description = "The secondary ranges associated with these subnets"
+}

--- a/3-networks/envs/production/variables.tf
+++ b/3-networks/envs/production/variables.tf
@@ -145,19 +145,3 @@ variable "enable_hub_and_spoke_transitivity" {
   type        = bool
   default     = false
 }
-
-
-variable "enable_development" {
-  description = "To enable creation of the development environment."
-  type        = bool
-}
-
-variable "enable_non_production" {
-  description = "To enable creation of the non-production environment."
-  type        = bool
-}
-
-variable "enable_production" {
-  description = "To enable creation of the production environment."
-  type        = bool
-}


### PR DESCRIPTION
**Context**
Originally, the intention was to have toggles/flags for customers to enable the creation of the three environments so customers do not need to request for quota. However, it seems impossible because on a fresh setup of a new Cloud Identity org, customers would face projects quota at the `1-org` step because cumulatively, 10 projects would be created at that time -- which I believe is the quota for new accounts.

**Rationale for PR**
I think the addition of toggles (to overcome the project quota) might be unnecessary and overly complicated, and it deviates away from the original Cloud security foundations example.com repo. I would think that documentations might help, at least at this point.

Therefore, in this PR:

- Removed toggles for 2-environments (i.e. no change from Cloud security foundations and reverts https://github.com/bankoncloud/terraform-example-foundation-sgmy-fsi/pull/22 and https://github.com/bankoncloud/terraform-example-foundation-sgmy-fsi/pull/25)
- Removed toggles for 3-networks (i.e. no change from Cloud security foundations and reverts https://github.com/bankoncloud/terraform-example-foundation-sgmy-fsi/pull/28)