### PR TITLE
feat: update default regions to asia or asia-southeast1

### DIFF
--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -165,7 +165,7 @@ the following steps:
 | billing\_account | The ID of the billing account to associate projects with. | `string` | n/a | yes |
 | bucket\_prefix | Name prefix to use for state bucket created. | `string` | `"bkt"` | no |
 | cloud\_source\_repos | List of Cloud Source Repositories created during bootstrap project build stage for use with Cloud Build. | `list(string)` | <pre>[<br>  "gcp-org",<br>  "gcp-environments",<br>  "gcp-networks",<br>  "gcp-projects"<br>]</pre> | no |
-| default\_region | Default region to create resources where applicable. | `string` | `"us-central1"` | no |
+| default\_region | Default region to create resources where applicable. | `string` | `"asia-southeast1"` | no |
 | folder\_prefix | Name prefix to use for folders created. Should be the same in all steps. | `string` | `"fldr"` | no |
 | group\_billing\_admins | Google Group for GCP Billing Administrators | `string` | n/a | yes |
 | group\_org\_admins | Google Group for GCP Organization Administrators | `string` | n/a | yes |

--- a/0-bootstrap/modules/jenkins-agent/README.md
+++ b/0-bootstrap/modules/jenkins-agent/README.md
@@ -22,7 +22,7 @@ module "jenkins_bootstrap" {
   folder_id                               = "<FOLDER_ID>"
   billing_account                         = "<BILLING_ACCOUNT_ID>"
   group_org_admins                        = "gcp-organization-admins@example.com"
-  default_region                          = "us-central1"
+  default_region                          = "asia-southeast1"
   terraform_service_account               = "<SERVICE_ACCOUNT_EMAIL>" # normally module.seed_bootstrap.terraform_sa_email
   terraform_sa_name                       = "<SERVICE_ACCOUNT_NAME>" # normally module.seed_bootstrap.terraform_sa_name
   terraform_state_bucket                  = "<GCS_STATE_BUCKET_NAME>" # normally module.seed_bootstrap.gcs_bucket_tfstate
@@ -54,7 +54,7 @@ module "jenkins_bootstrap" {
 | activate\_apis | List of APIs to enable in the CICD project. | `list(string)` | <pre>[<br>  "serviceusage.googleapis.com",<br>  "servicenetworking.googleapis.com",<br>  "compute.googleapis.com",<br>  "logging.googleapis.com",<br>  "bigquery.googleapis.com",<br>  "cloudresourcemanager.googleapis.com",<br>  "cloudbilling.googleapis.com",<br>  "iam.googleapis.com",<br>  "admin.googleapis.com",<br>  "appengine.googleapis.com",<br>  "storage-api.googleapis.com"<br>]</pre> | no |
 | bgp\_peer\_asn | BGP ASN for peer cloud routes. | `number` | `"64513"` | no |
 | billing\_account | The ID of the billing account to associate projects with. | `string` | n/a | yes |
-| default\_region | Default region to create resources where applicable. | `string` | `"us-central1"` | no |
+| default\_region | Default region to create resources where applicable. | `string` | `"asia-southeast1"` | no |
 | folder\_id | The ID of a folder to host this project | `string` | `""` | no |
 | group\_org\_admins | Google Group for GCP Organization Administrators | `string` | n/a | yes |
 | jenkins\_agent\_gce\_machine\_type | Jenkins Agent GCE Instance type. | `string` | `"n1-standard-1"` | no |

--- a/0-bootstrap/modules/jenkins-agent/variables.tf
+++ b/0-bootstrap/modules/jenkins-agent/variables.tf
@@ -36,7 +36,7 @@ variable "group_org_admins" {
 variable "default_region" {
   description = "Default region to create resources where applicable."
   type        = string
-  default     = "us-central1"
+  default     = "asia-southeast1"
 }
 
 /* ----------------------------------------

--- a/0-bootstrap/terraform.example.tfvars
+++ b/0-bootstrap/terraform.example.tfvars
@@ -22,7 +22,7 @@ group_org_admins = "gcp-organization-admins@example.com"
 
 group_billing_admins = "gcp-billing-admins@example.com"
 
-default_region = "us-central1"
+default_region = "asia-southeast1"
 
 // Optional - for an organization with existing projects or for development/validation.
 // Uncomment this variable to place all the example foundation resources under

--- a/0-bootstrap/variables.tf
+++ b/0-bootstrap/variables.tf
@@ -37,7 +37,7 @@ variable "group_billing_admins" {
 variable "default_region" {
   description = "Default region to create resources where applicable."
   type        = string
-  default     = "us-central1"
+  default     = "asia-southeast1"
 }
 
 variable "parent_folder" {

--- a/1-org/envs/shared/terraform.example.tfvars
+++ b/1-org/envs/shared/terraform.example.tfvars
@@ -27,7 +27,7 @@ billing_account = "000000-000000-000000"
 
 terraform_service_account = "org-terraform@example-project-2334.iam.gserviceaccount.com"
 
-default_region = "us-central1"
+default_region = "asia-southeast1"
 
 scc_notification_name = "scc-notify"
 

--- a/4-projects/business_unit_1/shared/README.md
+++ b/4-projects/business_unit_1/shared/README.md
@@ -7,7 +7,7 @@
 | alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded | `list(number)` | <pre>[<br>  0.5,<br>  0.75,<br>  0.9,<br>  0.95<br>]</pre> | no |
 | billing\_account | The ID of the billing account to associated this project with | `string` | n/a | yes |
 | budget\_amount | The amount to use as the budget | `number` | `1000` | no |
-| default\_region | Default region to create resources where applicable. | `string` | `"us-central1"` | no |
+| default\_region | Default region to create resources where applicable. | `string` | `"asia-southeast1"` | no |
 | folder\_prefix | Name prefix to use for folders created. Should be the same in all steps. | `string` | `"fldr"` | no |
 | org\_id | The organization id for the associated services | `string` | n/a | yes |
 | parent\_folder | Optional - for an organization with existing projects or for development/validation. It will place all the example foundation resources under the provided folder instead of the root organization. The value is the numeric folder ID. The folder must already exist. Must be the same value used in previous step. | `string` | `""` | no |

--- a/4-projects/business_unit_1/shared/variables.tf
+++ b/4-projects/business_unit_1/shared/variables.tf
@@ -17,7 +17,7 @@
 variable "default_region" {
   description = "Default region to create resources where applicable."
   type        = string
-  default     = "us-central1"
+  default     = "asia-southeast1"
 }
 
 variable "terraform_service_account" {

--- a/4-projects/business_unit_2/shared/README.md
+++ b/4-projects/business_unit_2/shared/README.md
@@ -7,7 +7,7 @@
 | alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded | `list(number)` | <pre>[<br>  0.5,<br>  0.75,<br>  0.9,<br>  0.95<br>]</pre> | no |
 | billing\_account | The ID of the billing account to associated this project with | `string` | n/a | yes |
 | budget\_amount | The amount to use as the budget | `number` | `1000` | no |
-| default\_region | Default region to create resources where applicable. | `string` | `"us-central1"` | no |
+| default\_region | Default region to create resources where applicable. | `string` | `"asia-southeast1"` | no |
 | folder\_prefix | Name prefix to use for folders created. | `string` | `"fldr"` | no |
 | org\_id | The organization id for the associated services | `string` | n/a | yes |
 | parent\_folder | Optional - if using a folder for testing. | `string` | `""` | no |

--- a/4-projects/business_unit_2/shared/variables.tf
+++ b/4-projects/business_unit_2/shared/variables.tf
@@ -17,7 +17,7 @@
 variable "default_region" {
   description = "Default region to create resources where applicable."
   type        = string
-  default     = "us-central1"
+  default     = "asia-southeast1"
 }
 
 variable "terraform_service_account" {

--- a/4-projects/modules/infra_pipelines/README.md
+++ b/4-projects/modules/infra_pipelines/README.md
@@ -5,7 +5,7 @@
 |------|-------------|------|---------|:--------:|
 | app\_infra\_repos | A list of Cloud Source Repos to be created to hold app infra Terraform configs | `list(string)` | n/a | yes |
 | billing\_account | The ID of the billing account to associated this project with | `string` | n/a | yes |
-| bucket\_region | Region to create GCS buckets for tfstate and Cloud Build artifacts | `string` | `"us-central1"` | no |
+| bucket\_region | Region to create GCS buckets for tfstate and Cloud Build artifacts | `string` | `"asia-southeast1"` | no |
 | cloudbuild\_apply\_filename | Path and name of Cloud Build YAML definition used for terraform apply. | `string` | `"cloudbuild-tf-apply.yaml"` | no |
 | cloudbuild\_plan\_filename | Path and name of Cloud Build YAML definition used for terraform plan. | `string` | `"cloudbuild-tf-plan.yaml"` | no |
 | cloudbuild\_project\_id | The project id where the pipelines and repos should be created | `string` | n/a | yes |

--- a/4-projects/modules/infra_pipelines/variables.tf
+++ b/4-projects/modules/infra_pipelines/variables.tf
@@ -54,7 +54,7 @@ variable "app_infra_repos" {
 variable "bucket_region" {
   description = "Region to create GCS buckets for tfstate and Cloud Build artifacts"
   type        = string
-  default     = "us-central1"
+  default     = "asia-southeast1"
 }
 
 variable "terraform_apply_branches" {

--- a/4-projects/shared.auto.example.tfvars
+++ b/4-projects/shared.auto.example.tfvars
@@ -15,4 +15,4 @@
  */
 
 # We suggest you to use the same region from the 0-bootstrap step
-default_region = "us-central1"
+default_region = "asia-southeast1"

--- a/5-app-infra/common.auto.example.tfvars
+++ b/5-app-infra/common.auto.example.tfvars
@@ -16,7 +16,7 @@
 
 org_id = "000000000000"
 
-instance_region = "us-central1" // should be one of the regions used to create network on step 3-networks
+instance_region = "asia-southeast1" // should be one of the regions used to create network on step 3-networks
 
 // Optional - for an organization with existing projects or for development/validation.
 // Must be the same value used in previous steps.

--- a/5-app-infra/modules/env_base/README.md
+++ b/5-app-infra/modules/env_base/README.md
@@ -10,7 +10,7 @@
 | machine\_type | Machine type to create, e.g. n1-standard-1 | `string` | `"f1-micro"` | no |
 | num\_instances | Number of instances to create | `number` | n/a | yes |
 | project\_suffix | The name of the GCP project. Max 16 characters with 3 character business unit code. | `string` | n/a | yes |
-| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| region | The GCP region to create and test resources in | `string` | `"asia-southeast1"` | no |
 | service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | `null` | no |
 | vpc\_type | The type of VPC to attach the project to. Possible options are base or restricted. | `string` | n/a | yes |
 

--- a/5-app-infra/modules/env_base/variables.tf
+++ b/5-app-infra/modules/env_base/variables.tf
@@ -27,7 +27,7 @@ variable "vpc_type" {
 variable "region" {
   description = "The GCP region to create and test resources in"
   type        = string
-  default     = "us-central1"
+  default     = "asia-southeast1"
 }
 
 variable "num_instances" {

--- a/test/fixtures/app-infra/main.tf
+++ b/test/fixtures/app-infra/main.tf
@@ -20,7 +20,7 @@ module "app_infra_bu1_development" {
   org_id                  = var.org_id
   project_service_account = var.terraform_service_account
   folder_prefix           = var.folder_prefix
-  instance_region         = "us-west1"
+  instance_region         = "asia-southeast1"
 }
 
 module "app_infra_bu1_nonproduction" {
@@ -29,7 +29,7 @@ module "app_infra_bu1_nonproduction" {
   org_id                  = var.org_id
   project_service_account = var.terraform_service_account
   folder_prefix           = var.folder_prefix
-  instance_region         = "us-west1"
+  instance_region         = "asia-southeast1"
 }
 
 module "app_infra_bu1_production" {
@@ -38,5 +38,5 @@ module "app_infra_bu1_production" {
   org_id                  = var.org_id
   project_service_account = var.terraform_service_account
   folder_prefix           = var.folder_prefix
-  instance_region         = "us-west1"
+  instance_region         = "asia-southeast1"
 }

--- a/test/fixtures/networks/main.tf
+++ b/test/fixtures/networks/main.tf
@@ -18,8 +18,8 @@ module "development" {
   source                           = "../../../3-networks/envs/development"
   org_id                           = var.org_id
   access_context_manager_policy_id = var.policy_id
-  default_region2                  = "us-central1"
-  default_region1                  = "us-west1"
+  default_region2                  = "asia-southeast2"
+  default_region1                  = "asia-southeast1"
   domain                           = var.domain
   terraform_service_account        = var.terraform_service_account
   parent_folder                    = var.parent_folder
@@ -30,8 +30,8 @@ module "non-production" {
   source                           = "../../../3-networks/envs/non-production"
   org_id                           = var.org_id
   access_context_manager_policy_id = var.policy_id
-  default_region2                  = "us-central1"
-  default_region1                  = "us-west1"
+  default_region2                  = "asia-southeast2"
+  default_region1                  = "asia-southeast1"
   domain                           = var.domain
   terraform_service_account        = var.terraform_service_account
   parent_folder                    = var.parent_folder
@@ -43,8 +43,8 @@ module "production" {
   source                           = "../../../3-networks/envs/production"
   org_id                           = var.org_id
   access_context_manager_policy_id = var.policy_id
-  default_region2                  = "us-central1"
-  default_region1                  = "us-west1"
+  default_region2                  = "asia-southeast2"
+  default_region1                  = "asia-southeast1"
   domain                           = var.domain
   terraform_service_account        = var.terraform_service_account
   parent_folder                    = var.parent_folder

--- a/test/fixtures/org/main.tf
+++ b/test/fixtures/org/main.tf
@@ -25,7 +25,7 @@ module "test" {
   org_id                                      = var.org_id
   billing_account                             = var.billing_account
   terraform_service_account                   = var.terraform_service_account
-  default_region                              = "us-east4"
+  default_region                              = "asia-southeast1"
   billing_data_users                          = var.group_email
   audit_data_users                            = var.group_email
   scc_notification_name                       = "test-scc-notif-${random_id.suffix.hex}"

--- a/test/fixtures/projects/main.tf
+++ b/test/fixtures/projects/main.tf
@@ -17,7 +17,7 @@
 module "bu1_shared" {
   source                    = "../../../4-projects/business_unit_1/shared"
   terraform_service_account = var.terraform_service_account
-  default_region            = "us-west1"
+  default_region            = "asia-southeast1"
   org_id                    = var.org_id
   billing_account           = var.billing_account
   parent_folder             = var.parent_folder
@@ -67,7 +67,7 @@ module "projects_bu1_prod" {
 module "bu2_shared" {
   source                    = "../../../4-projects/business_unit_2/shared"
   terraform_service_account = var.terraform_service_account
-  default_region            = "us-west1"
+  default_region            = "asia-southeast1"
   org_id                    = var.org_id
   billing_account           = var.billing_account
   parent_folder             = var.parent_folder

--- a/test/fixtures/shared/main.tf
+++ b/test/fixtures/shared/main.tf
@@ -16,8 +16,8 @@
 
 module "shared" {
   source                            = "../../../3-networks/envs/shared"
-  default_region1                   = "us-central1"
-  default_region2                   = "us-west1"
+  default_region1                   = "asia-southeast1"
+  default_region2                   = "asia-southeast2"
   domain                            = var.domain
   access_context_manager_policy_id  = var.policy_id
   target_name_server_addresses      = ["192.168.0.1", "192.168.0.2"]


### PR DESCRIPTION
Continuation from https://github.com/bankoncloud/terraform-example-foundation-sgmy-fsi/pull/27:

- Updated all multiregions to `asia`
- Updated all default regions to `asia-southeast1` (or in the case where resources require two regions, `asia-southeast2`)
- Updated all doc references to match the same