### PR TITLE
chore: disable confidential compute by default

### DIFF
--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -80,12 +80,13 @@ Also make sure that you've done the following:
       Cloud organization.
    -  The `roles/billing.admin` role on the billing account.
    -  The `roles/resourcemanager.folderCreator` role.
+1. Ensure that you have requested for sufficient projects quota, as the Terraform scripts will create multiple projects from this point onwards. For more information, please [see the FAQ](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/docs/FAQ.md).
 
 If other users need to be able to run these procedures, add them to the group
 represented by the `org_project_creators` variable.
 For more information about the permissions that are required, and the resources
 that are created, see the organization bootstrap module
-[documentation.](https://github.com/terraform-google-modules/terraform-google-bootstrap)
+[documentation](https://github.com/terraform-google-modules/terraform-google-bootstrap).
 
 ### Troubleshooting
 

--- a/1-org/README.md
+++ b/1-org/README.md
@@ -72,8 +72,7 @@ Enabling Data Access logs might result in your project being charged for the add
 For details on costs you might incur, go to [Pricing](https://cloud.google.com/stackdriver/pricing).
 You can choose not to enable the Data Access logs by setting variable `data_access_logs_enabled` to false.
 
-**Note:** This module creates a sink to export all logs to Google Storage. It also creates sinks to export a subset of security related logs
-to Bigquery and Pub/Sub. This will result in additional charges for those copies of logs.
+**Note:** This module creates a sink to export all logs to Google Storage. It also creates sinks to export a subset of security related logs to BigQuery and Pub/Sub. This will result in additional charges for those copies of logs.
 You can change the filters & sinks by modifying the configuration in `envs/shared/log_sinks.tf`.
 
 **Note:** Currently, this module does not enable [bucket policy retention](https://cloud.google.com/storage/docs/bucket-lock) for organization logs, please, enable it if needed.
@@ -102,9 +101,9 @@ FIs should configure the `log_export_storage_retention_policy` variable in `terr
 
 #### 💬 Organization Policy Constraints
 
-FIs should review `org_policy_mas_abs.tf` to review the following org-level constraints:
+In addition to the other Organization Policies, FIs should review `org_policy_mas_abs.tf` to evaluate if the following constraints are needed:
 
-- `constraints/compute.restrictNonConfidentialComputing` to restrict non-Confidential Computing resources from being created
+- `constraints/compute.restrictNonConfidentialComputing` to restrict non-Confidential Computing resources from being created (by default, this is disabled, although FIs can enable it and add specific folders or projects to be excluded from this constraint)
 - `constraints/storage.retentionPolicySeconds` to enforce Cloud Storage retention policy from a list of retention periods (by default, 1 hour and 30 days are configured)
 
 ### Deploying with Cloud Build

--- a/1-org/envs/shared/org_policy_mas_abs.tf
+++ b/1-org/envs/shared/org_policy_mas_abs.tf
@@ -25,8 +25,11 @@ module "confidential-computing" {
   folder_id       = local.folder_id
   policy_for      = local.policy_for
   policy_type     = "list"
-  enforce         = "true"
-  constraint      = "constraints/compute.restrictNonConfidentialComputing"
+  enforce         = "false"
+  // FIs can consider setting enforce = "true" and add exclusions instead
+  // exclude_folders   = ["folders/folder-1-id", "folders/folder-2-id"]
+  // exclude_projects  = ["project3", "project4"]
+  constraint = "constraints/compute.restrictNonConfidentialComputing"
 }
 
 // Example for CIS Control 2.3, MAS TRM 12.2.2 and ABS/B/14/Standard/2


### PR DESCRIPTION
In this PR, I disabled confidential compute org policy by default and added an example to show how FIs can use exclusion lists while enabling it.