### PR TITLE
feat: workload type for 4-projects

### DIFF
--- a/4-projects/business_unit_1/development/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/development/example_base_shared_vpc_project.tf
@@ -42,5 +42,6 @@ module "base_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }
 

--- a/4-projects/business_unit_1/development/example_floating_project.tf
+++ b/4-projects/business_unit_1/development/example_floating_project.tf
@@ -33,4 +33,5 @@ module "floating_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }

--- a/4-projects/business_unit_1/development/example_peering_project.tf
+++ b/4-projects/business_unit_1/development/example_peering_project.tf
@@ -55,6 +55,7 @@ module "peering_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }
 
 module "peering_network" {

--- a/4-projects/business_unit_1/development/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/development/example_restricted_shared_vpc_project.tf
@@ -39,4 +39,5 @@ module "restricted_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "material" # Example material workload project
 }

--- a/4-projects/business_unit_1/development/example_storage_cmek.tf
+++ b/4-projects/business_unit_1/development/example_storage_cmek.tf
@@ -35,6 +35,7 @@ module "env_secrets_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }
 
 data "google_storage_project_service_account" "gcs_account" {

--- a/4-projects/business_unit_1/non-production/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/non-production/example_base_shared_vpc_project.tf
@@ -42,4 +42,5 @@ module "base_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }

--- a/4-projects/business_unit_1/non-production/example_floating_project.tf
+++ b/4-projects/business_unit_1/non-production/example_floating_project.tf
@@ -33,4 +33,5 @@ module "floating_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }

--- a/4-projects/business_unit_1/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_1/non-production/example_peering_project.tf
@@ -55,6 +55,7 @@ module "peering_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }
 
 module "peering_network" {

--- a/4-projects/business_unit_1/non-production/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/non-production/example_restricted_shared_vpc_project.tf
@@ -39,5 +39,6 @@ module "restricted_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "material" # Example material workload project
 }
 

--- a/4-projects/business_unit_1/non-production/example_storage_cmek.tf
+++ b/4-projects/business_unit_1/non-production/example_storage_cmek.tf
@@ -35,6 +35,7 @@ module "env_secrets_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }
 
 data "google_storage_project_service_account" "gcs_account" {

--- a/4-projects/business_unit_1/production/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/production/example_base_shared_vpc_project.tf
@@ -42,4 +42,5 @@ module "base_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }

--- a/4-projects/business_unit_1/production/example_floating_project.tf
+++ b/4-projects/business_unit_1/production/example_floating_project.tf
@@ -33,4 +33,5 @@ module "floating_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }

--- a/4-projects/business_unit_1/production/example_peering_project.tf
+++ b/4-projects/business_unit_1/production/example_peering_project.tf
@@ -55,6 +55,7 @@ module "peering_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }
 
 module "peering_network" {

--- a/4-projects/business_unit_1/production/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/production/example_restricted_shared_vpc_project.tf
@@ -39,5 +39,6 @@ module "restricted_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "material" # Example material workload project
 }
 

--- a/4-projects/business_unit_1/production/example_storage_cmek.tf
+++ b/4-projects/business_unit_1/production/example_storage_cmek.tf
@@ -35,6 +35,7 @@ module "env_secrets_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu1"
+  workload_type     = "standard"
 }
 
 data "google_storage_project_service_account" "gcs_account" {

--- a/4-projects/business_unit_2/development/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/development/example_base_shared_vpc_project.tf
@@ -42,4 +42,5 @@ module "base_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }

--- a/4-projects/business_unit_2/development/example_floating_project.tf
+++ b/4-projects/business_unit_2/development/example_floating_project.tf
@@ -33,4 +33,5 @@ module "floating_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }

--- a/4-projects/business_unit_2/development/example_peering_project.tf
+++ b/4-projects/business_unit_2/development/example_peering_project.tf
@@ -55,6 +55,7 @@ module "peering_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }
 
 module "peering_network" {

--- a/4-projects/business_unit_2/development/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/development/example_restricted_shared_vpc_project.tf
@@ -39,4 +39,5 @@ module "restricted_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "material" # Example material workload project
 }

--- a/4-projects/business_unit_2/development/example_storage_cmek.tf
+++ b/4-projects/business_unit_2/development/example_storage_cmek.tf
@@ -35,6 +35,7 @@ module "env_secrets_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }
 
 data "google_storage_project_service_account" "gcs_account" {

--- a/4-projects/business_unit_2/non-production/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/non-production/example_base_shared_vpc_project.tf
@@ -42,4 +42,5 @@ module "base_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }

--- a/4-projects/business_unit_2/non-production/example_floating_project.tf
+++ b/4-projects/business_unit_2/non-production/example_floating_project.tf
@@ -35,4 +35,5 @@ module "floating_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }

--- a/4-projects/business_unit_2/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_2/non-production/example_peering_project.tf
@@ -55,6 +55,7 @@ module "peering_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }
 
 module "peering_network" {

--- a/4-projects/business_unit_2/non-production/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/non-production/example_restricted_shared_vpc_project.tf
@@ -39,4 +39,5 @@ module "restricted_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "material" # Example material workload project
 }

--- a/4-projects/business_unit_2/non-production/example_storage_cmek.tf
+++ b/4-projects/business_unit_2/non-production/example_storage_cmek.tf
@@ -35,6 +35,7 @@ module "env_secrets_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }
 
 data "google_storage_project_service_account" "gcs_account" {

--- a/4-projects/business_unit_2/production/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/production/example_base_shared_vpc_project.tf
@@ -42,4 +42,5 @@ module "base_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }

--- a/4-projects/business_unit_2/production/example_floating_project.tf
+++ b/4-projects/business_unit_2/production/example_floating_project.tf
@@ -35,4 +35,5 @@ module "floating_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }

--- a/4-projects/business_unit_2/production/example_peering_project.tf
+++ b/4-projects/business_unit_2/production/example_peering_project.tf
@@ -55,6 +55,7 @@ module "peering_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }
 
 module "peering_network" {

--- a/4-projects/business_unit_2/production/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/production/example_restricted_shared_vpc_project.tf
@@ -39,4 +39,5 @@ module "restricted_shared_vpc_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "material" # Example material workload project
 }

--- a/4-projects/business_unit_2/production/example_storage_cmek.tf
+++ b/4-projects/business_unit_2/production/example_storage_cmek.tf
@@ -35,6 +35,7 @@ module "env_secrets_project" {
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
   business_code     = "bu2"
+  workload_type     = "standard"
 }
 
 data "google_storage_project_service_account" "gcs_account" {

--- a/4-projects/modules/single_project/README.md
+++ b/4-projects/modules/single_project/README.md
@@ -26,6 +26,7 @@
 | vpc\_service\_control\_attach\_enabled | Whether the project will be attached to a VPC Service Control Perimeter | `bool` | `false` | no |
 | vpc\_service\_control\_perimeter\_name | The name of a VPC Service Control Perimeter to add the created project to | `string` | `null` | no |
 | vpc\_type | The type of VPC to attach the project to. Possible options are base or restricted. | `string` | `""` | no |
+| workload\_type | The type of workloads that this project hosts - e.g. `material`, `standard`, etc. according to an FI's own classification | `string` | `"standard"` | no |
 
 ## Outputs
 

--- a/4-projects/modules/single_project/main.tf
+++ b/4-projects/modules/single_project/main.tf
@@ -45,6 +45,7 @@ module "project" {
     business_code     = var.business_code
     env_code          = local.env_code
     vpc_type          = var.vpc_type
+    workload_type     = var.workload_type
   }
   budget_alert_pubsub_topic   = var.alert_pubsub_topic
   budget_alert_spent_percents = var.alert_spent_percents

--- a/4-projects/modules/single_project/variables.tf
+++ b/4-projects/modules/single_project/variables.tf
@@ -142,3 +142,9 @@ variable "cloudbuild_sa" {
   type        = string
   default     = ""
 }
+
+variable "workload_type" {
+  description = "The type of workloads that this project hosts - e.g. `material`, `standard`, etc. according to an FI's own classification"
+  type        = string
+  default     = "standard"
+}


### PR DESCRIPTION
In this PR, added a new `workload_type` project label so that FIs can classify their projects.

By default, it is set to `standard` just as an example. The labels are currently not used anywhere else.

Although some use cases could be:

- Cloud Functions to watch Cloud Asset Inventory changes for unauthorized IAM grants, and then send alerts depending on workload type (e.g. MAS standard workloads, or MAS critical workloads)