### PR TITLE
chore: update 4-projects README to explain process to change Cloud Build IAM roles

### DIFF
--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -111,6 +111,12 @@ Please refer to [troubleshooting](../docs/TROUBLESHOOTING.md) if you run into is
 **Note:** If you are using MacOS, replace `cp -RT` with `cp -R` in the relevant
 commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 
+### 💬 Updating Cloud Build Service Account IAM Roles
+
+By default, the original `example_base_shared_vpc_project.tf` comes with the `roles/editor` basic role, which may not be sufficient to deploy our example workloads. To show how FIs can modify the IAM roles, we changed the IAM roles to be more permissive only in `./business_unit_1/development/example_base_shared_vpc_project.tf`.
+
+We recommend FIs that the deployment of such infrastructure roles be done by a different team (separate from people who deploy the application workloads in the next step), and processes should be established to track such requests i.e. a maker-checker function, to meet specific MAS or ABS guidelines.
+
 ### Deploying with Cloud Build
 
 1. Clone repo.

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -106,14 +106,14 @@ Please refer to [troubleshooting](../docs/TROUBLESHOOTING.md) if you run into is
 
 ## Usage
 
-**Note:** You need to set variable `enable_hub_and_spoke` to `true` to be able to use the **Hub-and-Spoke** architecture detailed in the **Networking** section of the [google cloud security foundations guide](https://services.google.com/fh/files/misc/google-cloud-security-foundations-guide.pdf).
+**Note:** You need to set variable `enable_hub_and_spoke` to `true` to be able to use the **Hub-and-Spoke** architecture detailed in the **Networking** section of the [Google cloud security foundations guide](https://services.google.com/fh/files/misc/google-cloud-security-foundations-guide.pdf).
 
 **Note:** If you are using MacOS, replace `cp -RT` with `cp -R` in the relevant
 commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 
-### 💬 Updating Cloud Build Service Account IAM Roles
+### 💬 Establishing Processes for Changes to Cloud Build Service Account IAM Roles and Activated Google APIs
 
-By default, the original `example_base_shared_vpc_project.tf` comes with the `roles/editor` basic role, which may not be sufficient to deploy our example workloads. To show how FIs can modify the IAM roles, we changed the IAM roles to be more permissive only in `./business_unit_1/development/example_base_shared_vpc_project.tf`.
+By default, the original `example_base_shared_vpc_project.tf` comes with the `roles/editor` basic role and a limited scope of Google APIs, which may not be sufficient to deploy other workloads like GKE or Cloud SQL. FIs can modify the IAM roles `sa_roles` in these example files to grant more IAM roles, and the list of activated Google APIs `activate_apis`, while keeping the [principle of least privilege](https://cloud.google.com/iam/docs/using-iam-securely) in mind.
 
 We recommend FIs that the deployment of such infrastructure roles be done by a different team (separate from people who deploy the application workloads in the next step), and processes should be established to track such requests i.e. a maker-checker function, to meet specific MAS or ABS guidelines.
 

--- a/4-projects/business_unit_1/development/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/development/example_base_shared_vpc_project.tf
@@ -27,41 +27,12 @@ module "base_shared_vpc_project" {
   budget_amount               = var.budget_amount
   project_prefix              = var.project_prefix
   enable_hub_and_spoke        = var.enable_hub_and_spoke
+  sa_roles                    = ["roles/editor"]
   enable_cloudbuild_deploy    = true
   cloudbuild_sa               = var.app_infra_pipeline_cloudbuild_sa
-  // Review the following Cloud Build service account roles
-  // The person deploying these rules should be different from the person deploying workloads
-  sa_roles = [
-    "roles/editor",
-    "roles/compute.viewer",
-    "roles/compute.instanceAdmin.v1",
-    "roles/container.clusterAdmin",
-    "roles/container.developer",
-    "roles/iam.serviceAccountAdmin",
-    "roles/iam.serviceAccountUser",
-    "roles/resourcemanager.projectIamAdmin",
-    "roles/logging.configWriter",
-    "roles/storage.objectViewer",
-    "roles/iap.admin",
-    "roles/iam.roleAdmin",
-    "roles/binaryauthorization.policyEditor",
-    "roles/compute.securityAdmin",
-    "roles/compute.publicIpAdmin"
-  ]
   activate_apis = [
     "iam.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
-    "oslogin.googleapis.com",
-    "compute.googleapis.com",
-    "container.googleapis.com",
-    "monitoring.googleapis.com",
-    "logging.googleapis.com",
-    "cloudkms.googleapis.com",
-    "secretmanager.googleapis.com",
-    "cloudbilling.googleapis.com",
-    "serviceusage.googleapis.com",
-    "storage-api.googleapis.com",
-    "servicenetworking.googleapis.com"
+    "cloudresourcemanager.googleapis.com"
   ]
 
   # Metadata
@@ -73,4 +44,3 @@ module "base_shared_vpc_project" {
   business_code     = "bu1"
   workload_type     = "standard"
 }
-

--- a/4-projects/business_unit_1/development/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/development/example_base_shared_vpc_project.tf
@@ -27,12 +27,41 @@ module "base_shared_vpc_project" {
   budget_amount               = var.budget_amount
   project_prefix              = var.project_prefix
   enable_hub_and_spoke        = var.enable_hub_and_spoke
-  sa_roles                    = ["roles/editor"]
   enable_cloudbuild_deploy    = true
   cloudbuild_sa               = var.app_infra_pipeline_cloudbuild_sa
+  // Review the following Cloud Build service account roles
+  // The person deploying these rules should be different from the person deploying workloads
+  sa_roles = [
+    "roles/editor",
+    "roles/compute.viewer",
+    "roles/compute.instanceAdmin.v1",
+    "roles/container.clusterAdmin",
+    "roles/container.developer",
+    "roles/iam.serviceAccountAdmin",
+    "roles/iam.serviceAccountUser",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/logging.configWriter",
+    "roles/storage.objectViewer",
+    "roles/iap.admin",
+    "roles/iam.roleAdmin",
+    "roles/binaryauthorization.policyEditor",
+    "roles/compute.securityAdmin",
+    "roles/compute.publicIpAdmin"
+  ]
   activate_apis = [
     "iam.googleapis.com",
-    "cloudresourcemanager.googleapis.com"
+    "cloudresourcemanager.googleapis.com",
+    "oslogin.googleapis.com",
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "monitoring.googleapis.com",
+    "logging.googleapis.com",
+    "cloudkms.googleapis.com",
+    "secretmanager.googleapis.com",
+    "cloudbilling.googleapis.com",
+    "serviceusage.googleapis.com",
+    "storage-api.googleapis.com",
+    "servicenetworking.googleapis.com"
   ]
 
   # Metadata


### PR DESCRIPTION
In this PR:

- Added note for readers to understand that processes should be established to approve/reject changes in IAM grant & activated Google API requests (as required by specific MAS or ABS guidelines)

The following has been removed and no longer in this PR:
- Updated default IAM roles in `4-projects` to be more permissive (only Business Unit 1's Base Shared VPC service project), so that we can deploy GKE instances in the next step
